### PR TITLE
Allow tests to run against sqlite3 driver

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -63,10 +63,11 @@ module.exports = ({ env }) => {
   };
 
   const normalizedClient = connections[client] ? client : 'sqlite';
+  const clientForStrapi = normalizedClient === 'sqlite3' ? 'sqlite' : normalizedClient;
 
   return {
     connection: {
-      client: normalizedClient,
+      client: clientForStrapi,
       ...connections[normalizedClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },

--- a/config/database.js
+++ b/config/database.js
@@ -5,6 +5,19 @@ const path = require('path');
 module.exports = ({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
+  const defaultSqliteFilename = env('DATABASE_FILENAME', '.tmp/data.db');
+  const sqliteFilename =
+    defaultSqliteFilename === ':memory:'
+      ? ':memory:'
+      : path.join(__dirname, '..', '..', defaultSqliteFilename);
+
+  const sqliteConnection = {
+    connection: {
+      filename: sqliteFilename,
+    },
+    useNullAsDefault: true,
+  };
+
   const connections = {
     mysql: {
       connection: {
@@ -44,18 +57,17 @@ module.exports = ({ env }) => {
       },
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
-    sqlite: {
-      connection: {
-        filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
-      },
-      useNullAsDefault: true,
-    },
+    sqlite: sqliteConnection,
+    'better-sqlite3': sqliteConnection,
+    sqlite3: sqliteConnection,
   };
+
+  const normalizedClient = connections[client] ? client : 'sqlite';
 
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: normalizedClient,
+      ...connections[normalizedClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
   };

--- a/config/database.ts
+++ b/config/database.ts
@@ -61,10 +61,11 @@ export default ({ env }) => {
   };
 
   const normalizedClient = connections[client] ? client : 'sqlite';
+  const clientForStrapi = normalizedClient === 'sqlite3' ? 'sqlite' : normalizedClient;
 
   return {
     connection: {
-      client: normalizedClient,
+      client: clientForStrapi,
       ...connections[normalizedClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },

--- a/config/database.ts
+++ b/config/database.ts
@@ -3,6 +3,19 @@ import path from 'path';
 export default ({ env }) => {
   const client = env('DATABASE_CLIENT', 'sqlite');
 
+  const defaultSqliteFilename = env('DATABASE_FILENAME', '.tmp/data.db');
+  const sqliteFilename =
+    defaultSqliteFilename === ':memory:'
+      ? ':memory:'
+      : path.join(__dirname, '..', '..', defaultSqliteFilename);
+
+  const sqliteConnection = {
+    connection: {
+      filename: sqliteFilename,
+    },
+    useNullAsDefault: true,
+  } as const;
+
   const connections = {
     mysql: {
       connection: {
@@ -42,18 +55,17 @@ export default ({ env }) => {
       },
       pool: { min: env.int('DATABASE_POOL_MIN', 2), max: env.int('DATABASE_POOL_MAX', 10) },
     },
-    sqlite: {
-      connection: {
-        filename: path.join(__dirname, '..', '..', env('DATABASE_FILENAME', '.tmp/data.db')),
-      },
-      useNullAsDefault: true,
-    },
+    sqlite: sqliteConnection,
+    'better-sqlite3': sqliteConnection,
+    sqlite3: sqliteConnection,
   };
+
+  const normalizedClient = connections[client] ? client : 'sqlite';
 
   return {
     connection: {
-      client,
-      ...connections[client],
+      client: normalizedClient,
+      ...connections[normalizedClient],
       acquireConnectionTimeout: env.int('DATABASE_CONNECTION_TIMEOUT', 60000),
     },
   };

--- a/config/env/test/database.js
+++ b/config/env/test/database.js
@@ -1,9 +1,15 @@
-module.exports = ({ env }) => ({
-  connection: {
-    client: 'sqlite',
+module.exports = ({ env }) => {
+  const filename = env('DATABASE_FILENAME', '.tmp/test.db');
+  const requestedClient = env('DATABASE_CLIENT', 'sqlite');
+  const client = requestedClient === 'sqlite3' ? 'sqlite' : requestedClient;
+
+  return {
     connection: {
-      filename: env('DATABASE_FILENAME', '.tmp/test.db'),
+      client,
+      connection: {
+        filename,
+      },
+      useNullAsDefault: true,
     },
-    useNullAsDefault: true,
-  },
-});
+  };
+};

--- a/tests/strapi.js
+++ b/tests/strapi.js
@@ -8,6 +8,8 @@ process.env.ADMIN_JWT_SECRET = process.env.ADMIN_JWT_SECRET || 'test-admin-jwt-s
 process.env.TRANSFER_TOKEN_SALT = process.env.TRANSFER_TOKEN_SALT || 'test-transfer-token-salt';
 process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || '0123456789abcdef0123456789abcdef';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+process.env.DATABASE_CLIENT = process.env.DATABASE_CLIENT || 'sqlite3';
+process.env.DATABASE_FILENAME = process.env.DATABASE_FILENAME || ':memory:';
 process.env.STRAPI_DISABLE_CRON = 'true';
 
 let instance;


### PR DESCRIPTION
## Summary
- normalize the database configuration to support both better-sqlite3 and sqlite3 clients
- allow in-memory filenames for sqlite connections to avoid filesystem conflicts during tests
- force the Strapi test bootstrap to use the sqlite3 driver in memory so unit tests can run without native better-sqlite3 binaries

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_b_68dcf0952258833191d4d006ca8ccaa8