### PR TITLE
Normalize sqlite client configuration

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -3,7 +3,8 @@
 const path = require('path');
 
 module.exports = ({ env }) => {
-  const client = env('DATABASE_CLIENT', 'sqlite');
+  const rawClient = env('DATABASE_CLIENT', 'sqlite');
+  const client = ['sqlite3', 'better-sqlite3'].includes(rawClient) ? 'sqlite' : rawClient;
 
   const connections = {
     mysql: {

--- a/config/database.ts
+++ b/config/database.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 
 export default ({ env }) => {
-  const client = env('DATABASE_CLIENT', 'sqlite');
+  const rawClient = env('DATABASE_CLIENT', 'sqlite');
+  const client = ['sqlite3', 'better-sqlite3'].includes(rawClient) ? 'sqlite' : rawClient;
 
   const connections = {
     mysql: {

--- a/config/env/test/database.js
+++ b/config/env/test/database.js
@@ -1,9 +1,14 @@
-module.exports = ({ env }) => ({
-  connection: {
-    client: 'sqlite',
+module.exports = ({ env }) => {
+  const rawClient = env('DATABASE_CLIENT', 'sqlite');
+  const client = ['sqlite3', 'better-sqlite3'].includes(rawClient) ? 'sqlite' : rawClient;
+
+  return {
     connection: {
-      filename: env('DATABASE_FILENAME', '.tmp/test.db'),
+      client,
+      connection: {
+        filename: env('DATABASE_FILENAME', '.tmp/test.db'),
+      },
+      useNullAsDefault: true,
     },
-    useNullAsDefault: true,
-  },
-});
+  };
+};


### PR DESCRIPTION
## Summary
- normalize sqlite client names in the default database configuration to map `sqlite3` and `better-sqlite3` to Strapi's expected `sqlite`
- apply the same normalization to the test environment database override so Strapi never receives the unhandled client names

## Testing
- yarn test

------
https://chatgpt.com/codex/tasks/task_b_68dcfb1ccb208331aba74cc941594377