### PR TITLE
Handle better-sqlite3 client for Strapi tests

### DIFF
--- a/tests/strapi.js
+++ b/tests/strapi.js
@@ -10,6 +10,26 @@ process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || '0123456789abcdef0123
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
 process.env.STRAPI_DISABLE_CRON = 'true';
 
+const databaseClient = process.env.DATABASE_CLIENT || 'sqlite';
+const clientMap = {
+  sqlite: 'sqlite3',
+  'better-sqlite3': 'sqlite3',
+  mysql: 'mysql2',
+  postgres: 'pg',
+};
+
+const driver = clientMap[databaseClient];
+
+if (!driver) {
+  throw new Error(`Unsupported database client "${databaseClient}".`);
+}
+
+if (databaseClient === 'better-sqlite3') {
+  process.env.DATABASE_CLIENT = 'sqlite';
+}
+
+require(driver);
+
 let instance;
 
 async function setupStrapi() {


### PR DESCRIPTION
## Summary
- add a database client map in the Strapi test helper so sqlite and better-sqlite3 both resolve to sqlite3 while leaving mysql and postgres mappings unchanged
- normalize the DATABASE_CLIENT env var for better-sqlite3 runs and require the mapped driver before booting Strapi

## Testing
- DATABASE_CLIENT=better-sqlite3 yarn test

------
https://chatgpt.com/codex/tasks/task_b_68dcfe3aace08331a2fde35850004349